### PR TITLE
ENG-12957: Add section for S3 File Browser configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ To configure the sidecar to work on the S3 File Browser, set the following param
 If `sidecar_dns_hosted_zone_id` is omitted, the `sidecar_dns_name` won’t
 be automatically created, and the sidecar alias will need to be
 created after the deployment. See [Add a CNAME or A record for
-the sidecar](sidecars/manage/alias.mdx).
+the sidecar](https://cyral.com/docs/sidecars/manage/alias).
 
 For sidecars with support for S3, it is also a good practice to also
 attach the list of IAM Policies giving the sidecar all the required

--- a/README.md
+++ b/README.md
@@ -195,6 +195,42 @@ allowed inbound rules in the databases' security groups. If the databases do not
 analyze what is the proper networking configuration to allow connectivity from the EC2
 instances to the protected databases.
 
+#### Enable the S3 File Browser
+
+To configure the sidecar to work on the S3 File Browser, set the following parameters in your Terraform module:
+
+  ```
+  # Certificate related changes
+  load_balancer_tls_ports  = [443] # Port used to connect to the sidecar from the S3 browser
+  load_balancer_certificate_arn = "arn:aws:acm:<REGION>:<AWS_ACCOUNT>:certificate/<CERTIFICATE_ID>"
+  
+  # Custom DNS name (CNAME) related changes
+  sidecar_dns_hosted_zone_id = "<AWS_ROUTE_53_ZONE_ID>"
+  sidecar_dns_name = "<CNAME>" # ex: "www.sidecar-custom-name.com"
+  ```
+
+If `sidecar_dns_hosted_zone_id` is omitted, the `sidecar_dns_name` won’t
+be automatically created, and the sidecar alias will need to be
+created after the deployment. See [Add a CNAME or A record for
+the sidecar](sidecars/manage/alias.mdx).
+
+For sidecars with support for S3, it is also a good practice to also
+attach the list of IAM Policies giving the sidecar all the required
+permissions to assume IAM roles with access to S3:
+
+  ```
+  # IAM Policies to be attached to the sidecar, which allow the sidecar to 
+  # assume the desired IAM Roles with access to S3 buckets
+  iam_policies = ["arn:aws:iam::<AWS_ACCOUNT>:policy/<POLICY_NAME>"]
+  ```
+
+All the terraform parameters used above are documented in [GitHub:
+cyralinc/terraform-aws-sidecar-ec2: Cyral Sidecar module for 
+AWS EC2](https://github.com/cyralinc/terraform-aws-sidecar-ec2). For more 
+details about the S3 File Browser configuration, check the 
+[Enable the S3 File Browser](https://cyral.com/docs/how-to/enable-s3-browser) 
+documentation.
+
 ### Parameters
 
 See the full list of parameters in the [module's docs](https://registry.terraform.io/modules/cyralinc/sidecar-ec2/aws/latest?tab=inputs).


### PR DESCRIPTION
Add a section for S3 File Browser configuration, instructing how to configure the corresponding sidecar template parameters to work with S3 File Browser.