### PR TITLE
Bump tf module version to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ provider "aws" {
 
 module "cyral_sidecar" {
   source  = "cyralinc/sidecar-ec2/aws"  
-  version = "~> 4.0" # terraform module version
+  version = "~> 5.0" # terraform module version
 
   sidecar_id    = ""
   control_plane = ""
@@ -124,7 +124,7 @@ provider "aws" {
 
 module "cyral_sidecar" {
   source  = "cyralinc/sidecar-ec2/aws"  
-  version = "~> 4.0" # terraform module version
+  version = "~> 5.0" # terraform module version
 
   sidecar_id    = ""
   control_plane = ""


### PR DESCRIPTION
Depends on https://github.com/cyralinc/terraform-aws-sidecar-ec2/pull/118 and a new version `v5` of the module officially released.